### PR TITLE
Cannot overload nullptr_t with int, looser throw specification

### DIFF
--- a/json11.hpp
+++ b/json11.hpp
@@ -73,7 +73,7 @@ public:
 
     // Constructors for the various types of JSON value.
     Json() noexcept;                // NUL
-    Json(std::nullptr_t) noexcept;  // NUL
+    Json(std::nullptr_t);           // NUL
     Json(double value);             // NUMBER
     Json(int value);                // NUMBER
     Json(bool value);               // BOOL


### PR DESCRIPTION
This is because the "int" overload of this could potentially be called, as in the following circumstance:

Json myJson(NULL);

This creates a compiler error on Ubuntu gcc 4.8 due to the aforementioned potential ambiguity.
