### PR TITLE
Add include for cstring to test.cpp, for memcmp().

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <cstring>
 #include <cstdio>
 #include <iostream>
 #include <sstream>

--- a/test.cpp
+++ b/test.cpp
@@ -25,7 +25,7 @@ CHECK_TRAIT(is_nothrow_destructible<Json>);
 
 void parse_from_stdin() {
     string buf;
-    while (!std::cin.eof()) buf += std::cin.get();
+    while ( std::getline(std::cin, buf) ) {};
 
     string err;
     auto json = Json::parse(buf, err);


### PR DESCRIPTION
Couldn't compile using gcc 4.8.2 without adding #include <cstring> to the top of test.cpp.