### PR TITLE
Use static_cast instead of reinterpret_cast for hierarchy navigation.

### DIFF
--- a/json11.cpp
+++ b/json11.cpp
@@ -146,10 +146,10 @@ protected:
 
     // Comparisons
     bool equals(const JsonValue * other) const override {
-        return m_value == reinterpret_cast<const Value<tag, T> *>(other)->m_value;
+        return m_value == static_cast<const Value<tag, T> *>(other)->m_value;
     }
     bool less(const JsonValue * other) const override {
-        return m_value < reinterpret_cast<const Value<tag, T> *>(other)->m_value;
+        return m_value < static_cast<const Value<tag, T> *>(other)->m_value;
     }
 
     const T m_value;


### PR DESCRIPTION
First of all, please let me thank you for this nice library.

Currently, almost all compilers work fine without this patch,
but I think that this patch provides more compatibility.

In `Value::equals` and `Value::less`, `static_cast` should be used instead of `reinterpret_cast`.
I think that `reinterpret_cast` should not be used for hierarchy navigation between base and derived classes.
(Please refer to D&E C++ 14.3.2 static_cast part.)
Almost all compilers may work fine even if `reinterpret_cast` is used because `Value` does not have multiple or virtual base class,
but I think that `static_cast` is better from the point of the view of compatibility.

For hierarchy navigation, we should use `dynamic_cast` or `static_cast`.
In the case of `Value::equals`, the type of the argument `other` is well-known and it is same as the type of the receiver, `this`,
because `type()` of `this` and `other` is checked in `Json::operator==` in advance.
Therefore, we need not to use `dynamic_cast` and `static_cast` is safe.

Regards,
Murase
