### PR TITLE
VS2015CTP6 warning fixes

### DIFF
--- a/json11.cpp
+++ b/json11.cpp
@@ -381,19 +381,19 @@ struct JsonParser {
             return;
 
         if (pt < 0x80) {
-            out += pt;
+            out += static_cast<char>(pt);
         } else if (pt < 0x800) {
-            out += (pt >> 6) | 0xC0;
-            out += (pt & 0x3F) | 0x80;
+            out += static_cast<char>((pt >> 6) | 0xC0);
+            out += static_cast<char>((pt & 0x3F) | 0x80);
         } else if (pt < 0x10000) {
-            out += (pt >> 12) | 0xE0;
-            out += ((pt >> 6) & 0x3F) | 0x80;
-            out += (pt & 0x3F) | 0x80;
+            out += static_cast<char>((pt >> 12) | 0xE0);
+            out += static_cast<char>(((pt >> 6) & 0x3F) | 0x80);
+            out += static_cast<char>((pt & 0x3F) | 0x80);
         } else {
-            out += (pt >> 18) | 0xF0;
-            out += ((pt >> 12) & 0x3F) | 0x80;
-            out += ((pt >> 6) & 0x3F) | 0x80;
-            out += (pt & 0x3F) | 0x80;
+            out += static_cast<char>((pt >> 18) | 0xF0);
+            out += static_cast<char>(((pt >> 12) & 0x3F) | 0x80);
+            out += static_cast<char>(((pt >> 6) & 0x3F) | 0x80);
+            out += static_cast<char>((pt & 0x3F) | 0x80);
         }
     }
 

--- a/json11.cpp
+++ b/json11.cpp
@@ -376,26 +376,29 @@ struct JsonParser {
      *
      * Encode pt as UTF-8 and add it to out.
      */
-    void encode_utf8(long pt, string & out) {
-        if (pt < 0)
-            return;
+	void encode_utf8(long pt, string & out) {
+		if (pt < 0)
+			return;
 
-        if (pt < 0x80) {
-            out += pt;
-        } else if (pt < 0x800) {
-            out += (pt >> 6) | 0xC0;
-            out += (pt & 0x3F) | 0x80;
-        } else if (pt < 0x10000) {
-            out += (pt >> 12) | 0xE0;
-            out += ((pt >> 6) & 0x3F) | 0x80;
-            out += (pt & 0x3F) | 0x80;
-        } else {
-            out += (pt >> 18) | 0xF0;
-            out += ((pt >> 12) & 0x3F) | 0x80;
-            out += ((pt >> 6) & 0x3F) | 0x80;
-            out += (pt & 0x3F) | 0x80;
-        }
-    }
+		if (pt < 0x80) {
+			out += static_cast<char>(pt);
+		}
+		else if (pt < 0x800) {
+			out += static_cast<char>((pt >> 6) | 0xC0);
+			out += static_cast<char>((pt & 0x3F) | 0x80);
+		}
+		else if (pt < 0x10000) {
+			out += static_cast<char>((pt >> 12) | 0xE0);
+			out += static_cast<char>(((pt >> 6) & 0x3F) | 0x80);
+			out += static_cast<char>((pt & 0x3F) | 0x80);
+		}
+		else {
+			out += static_cast<char>((pt >> 18) | 0xF0);
+			out += static_cast<char>(((pt >> 12) & 0x3F) | 0x80);
+			out += static_cast<char>(((pt >> 6) & 0x3F) | 0x80);
+			out += static_cast<char>((pt & 0x3F) | 0x80);
+		}
+	}
 
     /* parse_string()
      *

--- a/json11.cpp
+++ b/json11.cpp
@@ -376,29 +376,26 @@ struct JsonParser {
      *
      * Encode pt as UTF-8 and add it to out.
      */
-	void encode_utf8(long pt, string & out) {
-		if (pt < 0)
-			return;
+    void encode_utf8(long pt, string & out) {
+        if (pt < 0)
+            return;
 
-		if (pt < 0x80) {
-			out += static_cast<char>(pt);
-		}
-		else if (pt < 0x800) {
-			out += static_cast<char>((pt >> 6) | 0xC0);
-			out += static_cast<char>((pt & 0x3F) | 0x80);
-		}
-		else if (pt < 0x10000) {
-			out += static_cast<char>((pt >> 12) | 0xE0);
-			out += static_cast<char>(((pt >> 6) & 0x3F) | 0x80);
-			out += static_cast<char>((pt & 0x3F) | 0x80);
-		}
-		else {
-			out += static_cast<char>((pt >> 18) | 0xF0);
-			out += static_cast<char>(((pt >> 12) & 0x3F) | 0x80);
-			out += static_cast<char>(((pt >> 6) & 0x3F) | 0x80);
-			out += static_cast<char>((pt & 0x3F) | 0x80);
-		}
-	}
+        if (pt < 0x80) {
+            out += pt;
+        } else if (pt < 0x800) {
+            out += (pt >> 6) | 0xC0;
+            out += (pt & 0x3F) | 0x80;
+        } else if (pt < 0x10000) {
+            out += (pt >> 12) | 0xE0;
+            out += ((pt >> 6) & 0x3F) | 0x80;
+            out += (pt & 0x3F) | 0x80;
+        } else {
+            out += (pt >> 18) | 0xF0;
+            out += ((pt >> 12) & 0x3F) | 0x80;
+            out += ((pt >> 6) & 0x3F) | 0x80;
+            out += (pt & 0x3F) | 0x80;
+        }
+    }
 
     /* parse_string()
      *


### PR DESCRIPTION
Explicitly added some casts because compiler is identifying potential truncation in utf8 conversion code.   The actual conversions look safe so I added some static_casts to express the intent explicitly.