### PR TITLE
changed int type to intmax_t

### DIFF
--- a/json11.cpp
+++ b/json11.cpp
@@ -24,6 +24,8 @@
 #include <cstdlib>
 #include <cstdio>
 #include <limits>
+#include <stdint.h>
+#include <inttypes.h>
 
 namespace json11 {
 
@@ -50,10 +52,14 @@ static void dump(double value, string &out) {
     out += buf;
 }
 
-static void dump(int value, string &out) {
+static void dump(intmax_t value, string &out) {
     char buf[32];
-    snprintf(buf, sizeof buf, "%d", value);
+    snprintf(buf, sizeof buf, "%" PRIdMAX, value);
     out += buf;
+}
+
+static void dump(int value, string &out) {
+    dump((intmax_t)value, out);
 }
 
 static void dump(bool value, string &out) {
@@ -158,20 +164,20 @@ protected:
 
 class JsonDouble final : public Value<Json::NUMBER, double> {
     double number_value() const override { return m_value; }
-    int int_value() const override { return static_cast<int>(m_value); }
+    intmax_t int_value() const override { return static_cast<intmax_t>(m_value); }
     bool equals(const JsonValue * other) const override { return m_value == other->number_value(); }
     bool less(const JsonValue * other)   const override { return m_value <  other->number_value(); }
 public:
     explicit JsonDouble(double value) : Value(value) {}
 };
 
-class JsonInt final : public Value<Json::NUMBER, int> {
+class JsonInt final : public Value<Json::NUMBER, intmax_t> {
     double number_value() const override { return m_value; }
-    int int_value() const override { return m_value; }
+    intmax_t int_value() const override { return m_value; }
     bool equals(const JsonValue * other) const override { return m_value == other->number_value(); }
     bool less(const JsonValue * other)   const override { return m_value <  other->number_value(); }
 public:
-    explicit JsonInt(int value) : Value(value) {}
+    explicit JsonInt(intmax_t value) : Value(value) {}
 };
 
 class JsonBoolean final : public Value<Json::BOOL, bool> {
@@ -240,6 +246,7 @@ Json::Json() noexcept                  : m_ptr(statics().null) {}
 Json::Json(std::nullptr_t) noexcept    : m_ptr(statics().null) {}
 Json::Json(double value)               : m_ptr(make_shared<JsonDouble>(value)) {}
 Json::Json(int value)                  : m_ptr(make_shared<JsonInt>(value)) {}
+Json::Json(intmax_t value)             : m_ptr(make_shared<JsonInt>(value)) {}
 Json::Json(bool value)                 : m_ptr(value ? statics().t : statics().f) {}
 Json::Json(const string &value)        : m_ptr(make_shared<JsonString>(value)) {}
 Json::Json(string &&value)             : m_ptr(make_shared<JsonString>(move(value))) {}
@@ -255,7 +262,7 @@ Json::Json(Json::object &&values)      : m_ptr(make_shared<JsonObject>(move(valu
 
 Json::Type Json::type()                           const { return m_ptr->type();         }
 double Json::number_value()                       const { return m_ptr->number_value(); }
-int Json::int_value()                             const { return m_ptr->int_value();    }
+intmax_t Json::int_value()                             const { return m_ptr->int_value();    }
 bool Json::bool_value()                           const { return m_ptr->bool_value();   }
 const string & Json::string_value()               const { return m_ptr->string_value(); }
 const vector<Json> & Json::array_items()          const { return m_ptr->array_items();  }
@@ -264,7 +271,7 @@ const Json & Json::operator[] (size_t i)          const { return (*m_ptr)[i];   
 const Json & Json::operator[] (const string &key) const { return (*m_ptr)[key];         }
 
 double                    JsonValue::number_value()              const { return 0; }
-int                       JsonValue::int_value()                 const { return 0; }
+intmax_t                  JsonValue::int_value()                 const { return 0; }
 bool                      JsonValue::bool_value()                const { return false; }
 const string &            JsonValue::string_value()              const { return statics().empty_string; }
 const vector<Json> &      JsonValue::array_items()               const { return statics().empty_vector; }

--- a/json11.cpp
+++ b/json11.cpp
@@ -245,7 +245,6 @@ const Json & static_null() {
 Json::Json() noexcept                  : m_ptr(statics().null) {}
 Json::Json(std::nullptr_t) noexcept    : m_ptr(statics().null) {}
 Json::Json(double value)               : m_ptr(make_shared<JsonDouble>(value)) {}
-Json::Json(int value)                  : m_ptr(make_shared<JsonInt>(value)) {}
 Json::Json(intmax_t value)             : m_ptr(make_shared<JsonInt>(value)) {}
 Json::Json(bool value)                 : m_ptr(value ? statics().t : statics().f) {}
 Json::Json(const string &value)        : m_ptr(make_shared<JsonString>(value)) {}

--- a/json11.hpp
+++ b/json11.hpp
@@ -76,7 +76,6 @@ public:
     Json() noexcept;                // NUL
     Json(std::nullptr_t) noexcept;  // NUL
     Json(double value);             // NUMBER
-    Json(int value);                // NUMBER
     Json(intmax_t value);           // NUMBER
     Json(bool value);               // BOOL
     Json(const std::string &value); // STRING
@@ -86,6 +85,10 @@ public:
     Json(array &&values);           // ARRAY
     Json(const object &values);     // OBJECT
     Json(object &&values);          // OBJECT
+
+    // Integer constructor
+    template<typename T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+    Json(T value) : Json(intmax_t(value)){}
 
     // Implicit constructor: anything with a to_json() function.
     template <class T, class = decltype(&T::to_json)>

--- a/json11.hpp
+++ b/json11.hpp
@@ -55,6 +55,7 @@
 #include <map>
 #include <memory>
 #include <initializer_list>
+#include <cstdint>
 
 namespace json11 {
 
@@ -76,6 +77,7 @@ public:
     Json(std::nullptr_t) noexcept;  // NUL
     Json(double value);             // NUMBER
     Json(int value);                // NUMBER
+    Json(intmax_t value);           // NUMBER
     Json(bool value);               // BOOL
     Json(const std::string &value); // STRING
     Json(std::string &&value);      // STRING
@@ -120,7 +122,7 @@ public:
     // distinguish between integer and non-integer numbers - number_value() and int_value()
     // can both be applied to a NUMBER-typed object.
     double number_value() const;
-    int int_value() const;
+    intmax_t int_value() const;
 
     // Return the enclosed value if this is a boolean, false otherwise.
     bool bool_value() const;
@@ -187,7 +189,7 @@ protected:
     virtual bool less(const JsonValue * other) const = 0;
     virtual void dump(std::string &out) const = 0;
     virtual double number_value() const;
-    virtual int int_value() const;
+    virtual intmax_t int_value() const;
     virtual bool bool_value() const;
     virtual const std::string &string_value() const;
     virtual const Json::array &array_items() const;


### PR DESCRIPTION
I need to **serialize** value (long timestamp in 10^7 Hz timer) exactly as int, so I added support for uint64_t integers on 64-bit platforms via intmax_t type.

On 32-bit platforms (no under my hand to test) everything should work well.