### PR TITLE
Fix -Wconversion and -Wsign-conversion Clang warnings.

### DIFF
--- a/json11.cpp
+++ b/json11.cpp
@@ -367,7 +367,7 @@ struct JsonParser {
     char get_next_token() {
         consume_whitespace();
         if (i == str.size())
-            return fail("unexpected end of input", 0);
+            return fail("unexpected end of input", char{});
 
         return str[i++];
     }
@@ -435,7 +435,7 @@ struct JsonParser {
             if (ch == 'u') {
                 // Extract 4-byte escape sequence
                 string esc = str.substr(i, 4);
-                for (int j = 0; j < 4; j++) {
+                for (size_t j = 0; j < 4; ++j) {
                     if (!in_range(esc[j], 'a', 'f') && !in_range(esc[j], 'A', 'F')
                             && !in_range(esc[j], '0', '9'))
                         return fail("bad \\u escape: " + esc, "");


### PR DESCRIPTION
I use _json11_ in my own [project](https://github.com/yazevnul/ysda-search-engine), which I usually compile with Clang and have following warnings:

/Users/yazevnul/Documents/my/github/ysda-search-engine/src/third_party/json11/json11.cpp:370:20: warning: implicit conversion loses integer precision: 'int' to 'char' [-Wconversion]
            return fail("unexpected end of input", 0);
            ~~~~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/yazevnul/Documents/my/github/ysda-search-engine/src/third_party/json11/json11.cpp:439:39: warning: implicit conversion changes signedness: 'int' to 'size_type'
      (aka 'unsigned long') [-Wsign-conversion]
                    if (!in_range(esc[j], 'a', 'f') && !in_range(esc[j], 'A', 'F')
                                  ~~~ ^
/Users/yazevnul/Documents/my/github/ysda-search-engine/src/third_party/json11/json11.cpp:439:70: warning: implicit conversion changes signedness: 'int' to 'size_type'
      (aka 'unsigned long') [-Wsign-conversion]
                    if (!in_range(esc[j], 'a', 'f') && !in_range(esc[j], 'A', 'F')
                                                                 ~~~ ^
/Users/yazevnul/Documents/my/github/ysda-search-engine/src/third_party/json11/json11.cpp:440:46: warning: implicit conversion changes signedness: 'int' to 'size_type'
      (aka 'unsigned long') [-Wsign-conversion]
                            && !in_range(esc[j], '0', '9'))

This PR should fix them.
