### PR TITLE
When dumping non-finite floating point values, output 'null'.

### DIFF
--- a/json11.cpp
+++ b/json11.cpp
@@ -21,6 +21,7 @@
 
 #include "json11.hpp"
 #include <cassert>
+#include <cmath>
 #include <cstdlib>
 #include <cstdio>
 #include <limits>
@@ -45,9 +46,13 @@ static void dump(std::nullptr_t, string &out) {
 }
 
 static void dump(double value, string &out) {
-    char buf[32];
-    snprintf(buf, sizeof buf, "%.17g", value);
-    out += buf;
+    if (std::isfinite(value)) {
+        char buf[32];
+        snprintf(buf, sizeof buf, "%.17g", value);
+        out += buf;
+    } else {
+        out += "null";
+    }
 }
 
 static void dump(int value, string &out) {


### PR DESCRIPTION
In JSON the float point special values NaN and Infinity should serialised to 'null'.
Previously, 'snprintf' in 'dump' was giving a string that isn't compliant to the JSON standard.