### PR TITLE
Add cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+project(json11)
+
+cmake_minimum_required(VERSION 2.8)
+
+enable_testing()
+
+add_definitions(
+    -std=c++11
+    -fno-rtti
+    -fno-exceptions
+    -Wall
+    -Wextra
+    -Werror)
+
+set(json11_SRCS json11.cpp)
+
+add_library(json11 STATIC ${json11_SRCS})
+
+add_test(json11_test json11_test)
+
+add_executable(json11_test ${json11_SRCS} test.cpp)


### PR DESCRIPTION
This uses cmake to allow building as a static library and to build the tests

To use `cmake`

```
$ mkdir build
$ cd build
$ cmake ..
 .
 .
-- Build files have been written to: ~/json11/build
$ make
Scanning dependencies of target json11
[ 20%] Building CXX object CMakeFiles/json11.dir/json11.cpp.o
[ 40%] Linking CXX static library libjson11.a
[ 40%] Built target json11
Scanning dependencies of target json11_test
[ 60%] Building CXX object CMakeFiles/json11_test.dir/json11.cpp.o
[ 80%] Building CXX object CMakeFiles/json11_test.dir/test.cpp.o
[100%] Linking CXX executable json11_test
[100%] Built target json11_test
$ make test
running tests...
Test project ~/json11/build
    Start 1: json11_test
    1/1 Test #1: json11_test ......................   Passed    0.00 sec

    100% tests passed, 0 tests failed out of 1

    Total Test time (real) =   0.01 sec
$
```