### PR TITLE
Detect comments

### DIFF
--- a/json11.cpp
+++ b/json11.cpp
@@ -369,7 +369,8 @@ struct JsonParser {
      *
      * Advance comments (c-style inline and multiline).
      */
-    void consume_comment() {
+    bool consume_comment() {
+      bool comment_found = false;
       if (str[i] == '/') {
         i++;
         if (str[i] == '/') { // inline comment
@@ -377,8 +378,7 @@ struct JsonParser {
           // advance until next line
           while (str[i] != '\n')
             i++;
-          consume_whitespace();
-          consume_comment();
+          comment_found = true;
         }
         else if (str[i] == '*') { // multiline comment
           i++;
@@ -386,10 +386,10 @@ struct JsonParser {
           while (!(str[i] == '*' && str[i+1] == '/'))
             i++;
           i += 2;
-          consume_whitespace();
-          consume_comment();
+          comment_found = true;
         }
       }
+      return comment_found;
     }
 
     /* consume_garbage()
@@ -399,8 +399,12 @@ struct JsonParser {
     void consume_garbage() {
       consume_whitespace();
       if(detect_comments) {
-        consume_comment();
-        consume_whitespace();
+        bool comment_found = false;
+        do {
+          comment_found = consume_comment();
+          consume_whitespace();
+        }
+        while(comment_found);
       }
     }
 

--- a/json11.cpp
+++ b/json11.cpp
@@ -338,6 +338,7 @@ struct JsonParser {
     size_t i;
     string &err;
     bool failed;
+    bool detect_comments;
 
     /* fail(msg, err_ret = Json())
      *
@@ -397,10 +398,10 @@ struct JsonParser {
      */
     void consume_garbage() {
       consume_whitespace();
-#ifdef JSON11_COMMENTS
-      consume_comment();
-      consume_whitespace();
-#endif
+      if(detect_comments) {
+        consume_comment();
+        consume_whitespace();
+      }
     }
 
     /* get_next_token()
@@ -696,8 +697,8 @@ struct JsonParser {
     }
 };
 
-Json Json::parse(const string &in, string &err) {
-    JsonParser parser { in, 0, err, false };
+Json Json::parse(const string &in, string &err, bool detect_comments) {
+    JsonParser parser { in, 0, err, false, detect_comments };
     Json result = parser.parse_json(0);
 
     // Check for any trailing garbage
@@ -709,8 +710,10 @@ Json Json::parse(const string &in, string &err) {
 }
 
 // Documented in json11.hpp
-vector<Json> Json::parse_multi(const string &in, string &err) {
-    JsonParser parser { in, 0, err, false };
+vector<Json> Json::parse_multi(const string &in,
+                               string &err,
+                               bool detect_comments) {
+    JsonParser parser { in, 0, err, false, detect_comments };
 
     vector<Json> json_vec;
     while (parser.i != in.size() && !parser.failed) {

--- a/json11.cpp
+++ b/json11.cpp
@@ -338,7 +338,7 @@ struct JsonParser {
     size_t i;
     string &err;
     bool failed;
-    bool detect_comments;
+    JsonParse strategy;
 
     /* fail(msg, err_ret = Json())
      *
@@ -416,7 +416,7 @@ struct JsonParser {
      */
     void consume_garbage() {
       consume_whitespace();
-      if(detect_comments) {
+      if(strategy == JsonParse::COMMENTS) {
         bool comment_found = false;
         do {
           comment_found = consume_comment();
@@ -719,8 +719,8 @@ struct JsonParser {
     }
 };
 
-Json Json::parse(const string &in, string &err, bool detect_comments) {
-    JsonParser parser { in, 0, err, false, detect_comments };
+Json Json::parse(const string &in, string &err, JsonParse strategy) {
+    JsonParser parser { in, 0, err, false, strategy };
     Json result = parser.parse_json(0);
 
     // Check for any trailing garbage
@@ -734,8 +734,8 @@ Json Json::parse(const string &in, string &err, bool detect_comments) {
 // Documented in json11.hpp
 vector<Json> Json::parse_multi(const string &in,
                                string &err,
-                               bool detect_comments) {
-    JsonParser parser { in, 0, err, false, detect_comments };
+                               JsonParse strategy) {
+    JsonParser parser { in, 0, err, false, strategy };
 
     vector<Json> json_vec;
     while (parser.i != in.size() && !parser.failed) {

--- a/json11.cpp
+++ b/json11.cpp
@@ -338,7 +338,7 @@ struct JsonParser {
     size_t i;
     string &err;
     bool failed;
-    JsonParse strategy;
+    const JsonParse strategy;
 
     /* fail(msg, err_ret = Json())
      *

--- a/json11.cpp
+++ b/json11.cpp
@@ -391,13 +391,25 @@ struct JsonParser {
       }
     }
 
+    /* consume_garbage()
+     *
+     * Advance until the current character is non-whitespace and non-comment.
+     */
+    void consume_garbage() {
+      consume_whitespace();
+#ifdef JSON11_COMMENTS
+      consume_comment();
+      consume_whitespace();
+#endif
+    }
+
     /* get_next_token()
      *
      * Return the next non-whitespace character. If the end of the input is reached,
      * flag an error and return 0.
      */
     char get_next_token() {
-        consume_whitespace();
+        consume_garbage();
         if (i == str.size())
             return fail("unexpected end of input", 0);
 
@@ -689,7 +701,7 @@ Json Json::parse(const string &in, string &err) {
     Json result = parser.parse_json(0);
 
     // Check for any trailing garbage
-    parser.consume_whitespace();
+    parser.consume_garbage();
     if (parser.i != in.size())
         return parser.fail("unexpected trailing " + esc(in[parser.i]));
 
@@ -704,7 +716,7 @@ vector<Json> Json::parse_multi(const string &in, string &err) {
     while (parser.i != in.size() && !parser.failed) {
         json_vec.push_back(parser.parse_json(0));
         // Check for another object
-        parser.consume_whitespace();
+        parser.consume_garbage();
     }
     return json_vec;
 }

--- a/json11.cpp
+++ b/json11.cpp
@@ -383,11 +383,16 @@ struct JsonParser {
         else if (str[i] == '*') { // multiline comment
           i++;
            // advance until closing tokens
-          while (!(str[i] == '*' && str[i+1] == '/'))
-            i++;
+          while (!(str[i] == '*' && str[i+1] == '/')) {
+            if (i == str.size())
+              return fail(
+                "unexpected end of input inside multi-line comment", 0);
+            i++;}
           i += 2;
           comment_found = true;
         }
+        else
+          return fail("malformed comment", 0);
       }
       return comment_found;
     }

--- a/json11.cpp
+++ b/json11.cpp
@@ -389,12 +389,12 @@ struct JsonParser {
         }
         else if (str[i] == '*') { // multiline comment
           i++;
-          if (i == str.size())
+          if (i > str.size()-2)
             return fail("unexpected end of input inside multi-line comment", 0);
-           // advance until closing tokens
+          // advance until closing tokens
           while (!(str[i] == '*' && str[i+1] == '/')) {
             i++;
-            if (i == str.size())
+            if (i > str.size()-2)
               return fail(
                 "unexpected end of input inside multi-line comment", 0);
           }

--- a/json11.cpp
+++ b/json11.cpp
@@ -373,22 +373,35 @@ struct JsonParser {
       bool comment_found = false;
       if (str[i] == '/') {
         i++;
+        if (i == str.size())
+          return fail("unexpected end of input inside comment", 0);
         if (str[i] == '/') { // inline comment
           i++;
+          if (i == str.size())
+            return fail("unexpected end of input inside inline comment", 0);
           // advance until next line
-          while (str[i] != '\n')
+          while (str[i] != '\n') {
             i++;
+            if (i == str.size())
+              return fail("unexpected end of input inside inline comment", 0);
+          }
           comment_found = true;
         }
         else if (str[i] == '*') { // multiline comment
           i++;
+          if (i == str.size())
+            return fail("unexpected end of input inside multi-line comment", 0);
            // advance until closing tokens
           while (!(str[i] == '*' && str[i+1] == '/')) {
+            i++;
             if (i == str.size())
               return fail(
                 "unexpected end of input inside multi-line comment", 0);
-            i++;}
+          }
           i += 2;
+          if (i == str.size())
+            return fail(
+              "unexpected end of input inside multi-line comment", 0);
           comment_found = true;
         }
         else

--- a/json11.cpp
+++ b/json11.cpp
@@ -364,6 +364,33 @@ struct JsonParser {
             i++;
     }
 
+    /* consume_comment()
+     *
+     * Advance comments (c-style inline and multiline).
+     */
+    void consume_comment() {
+      if (str[i] == '/') {
+        i++;
+        if (str[i] == '/') { // inline comment
+          i++;
+          // advance until next line
+          while (str[i] != '\n')
+            i++;
+          consume_whitespace();
+          consume_comment();
+        }
+        else if (str[i] == '*') { // multiline comment
+          i++;
+           // advance until closing tokens
+          while (!(str[i] == '*' && str[i+1] == '/'))
+            i++;
+          i += 2;
+          consume_whitespace();
+          consume_comment();
+        }
+      }
+    }
+
     /* get_next_token()
      *
      * Return the next non-whitespace character. If the end of the input is reached,

--- a/json11.hpp
+++ b/json11.hpp
@@ -56,8 +56,6 @@
 #include <memory>
 #include <initializer_list>
 
-#define JSON11_COMMENTS 1
-
 namespace json11 {
 
 class JsonValue;
@@ -147,17 +145,23 @@ public:
     }
 
     // Parse. If parse fails, return Json() and assign an error message to err.
-    static Json parse(const std::string & in, std::string & err);
-    static Json parse(const char * in, std::string & err) {
+    static Json parse(const std::string & in,
+                      std::string & err,
+                      bool detect_comments = false);
+    static Json parse(const char * in,
+                      std::string & err,
+                      bool detect_comments = false) {
         if (in) {
-            return parse(std::string(in), err);
+            return parse(std::string(in), err, detect_comments);
         } else {
             err = "null input";
             return nullptr;
         }
     }
     // Parse multiple objects, concatenated or separated by whitespace
-    static std::vector<Json> parse_multi(const std::string & in, std::string & err);
+    static std::vector<Json> parse_multi(const std::string & in,
+                                         std::string & err,
+                                         bool detect_comments = false);
 
     bool operator== (const Json &rhs) const;
     bool operator<  (const Json &rhs) const;

--- a/json11.hpp
+++ b/json11.hpp
@@ -58,6 +58,10 @@
 
 namespace json11 {
 
+enum JsonParse {
+    STANDARD, COMMENTS
+};
+
 class JsonValue;
 
 class Json final {
@@ -147,21 +151,22 @@ public:
     // Parse. If parse fails, return Json() and assign an error message to err.
     static Json parse(const std::string & in,
                       std::string & err,
-                      bool detect_comments = false);
+                      JsonParse strategy = JsonParse::STANDARD);
     static Json parse(const char * in,
                       std::string & err,
-                      bool detect_comments = false) {
+                      JsonParse strategy = JsonParse::STANDARD) {
         if (in) {
-            return parse(std::string(in), err, detect_comments);
+            return parse(std::string(in), err, strategy);
         } else {
             err = "null input";
             return nullptr;
         }
     }
     // Parse multiple objects, concatenated or separated by whitespace
-    static std::vector<Json> parse_multi(const std::string & in,
-                                         std::string & err,
-                                         bool detect_comments = false);
+    static std::vector<Json> parse_multi(
+        const std::string & in,
+        std::string & err,
+        JsonParse strategy = JsonParse::STANDARD);
 
     bool operator== (const Json &rhs) const;
     bool operator<  (const Json &rhs) const;

--- a/json11.hpp
+++ b/json11.hpp
@@ -56,6 +56,8 @@
 #include <memory>
 #include <initializer_list>
 
+#define JSON11_COMMENTS 1
+
 namespace json11 {
 
 class JsonValue;

--- a/test.cpp
+++ b/test.cpp
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
     }
 
     failing_comment_test = R"({
-          "a": 1,
+          "a": 1
         }/)";
 
     json_failing_comment = Json::parse(

--- a/test.cpp
+++ b/test.cpp
@@ -58,6 +58,28 @@ int main(int argc, char **argv) {
         std::cout << "    - " << k.dump() << "\n";
     }
 
+#ifdef JSON11_COMMENTS
+    const string comment_test = R"({
+      // comment
+      "a": 1,
+      // comment
+      // continued
+      "b": "text",
+      /* multi
+         line
+         comment */
+      "c": [1, 2, 3]
+    })";
+
+    string err_comment;
+    auto json_comment = Json::parse(comment_test, err_comment);
+    if (!err_comment.empty()) {
+        printf("Failed: %s\n", err_comment.c_str());
+    } else {
+        printf("Result: %s\n", json_comment.dump().c_str());
+    }
+#endif
+
     std::list<int> l1 { 1, 2, 3 };
     std::vector<int> l2 { 1, 2, 3 };
     std::set<int> l3 { 1, 2, 3 };

--- a/test.cpp
+++ b/test.cpp
@@ -105,6 +105,16 @@ int main(int argc, char **argv) {
         printf("Result: %s\n", json_failing_comment.dump().c_str());
     }
 
+    failing_comment_test = R"({// bad comment })";
+
+    json_failing_comment = Json::parse(
+      failing_comment_test, err_failing_comment, /*detect_comments=*/ true);
+    if (!err_failing_comment.empty()) {
+        printf("Failed: %s\n", err_failing_comment.c_str());
+    } else {
+        printf("Result: %s\n", json_failing_comment.dump().c_str());
+    }
+
     failing_comment_test = R"({
           "a": 1
         }/)";

--- a/test.cpp
+++ b/test.cpp
@@ -80,6 +80,45 @@ int main(int argc, char **argv) {
         printf("Result: %s\n", json_comment.dump().c_str());
     }
 
+    string failing_comment_test = R"({
+      /* bad comment
+      "a": 1,
+    })";
+
+    string err_failing_comment;
+    auto json_failing_comment = Json::parse(
+      failing_comment_test, err_failing_comment, /*detect_comments=*/ true);
+    if (!err_failing_comment.empty()) {
+        printf("Failed: %s\n", err_failing_comment.c_str());
+    } else {
+        printf("Result: %s\n", json_failing_comment.dump().c_str());
+    }
+
+    failing_comment_test = R"({
+      / / bad comment
+      "a": 1,
+    })";
+
+    json_failing_comment = Json::parse(
+      failing_comment_test, err_failing_comment, /*detect_comments=*/ true);
+    if (!err_failing_comment.empty()) {
+        printf("Failed: %s\n", err_failing_comment.c_str());
+    } else {
+        printf("Result: %s\n", json_failing_comment.dump().c_str());
+    }
+
+    failing_comment_test = R"({
+          "a": 1,
+        }/)";
+
+    json_failing_comment = Json::parse(
+      failing_comment_test, err_failing_comment, /*detect_comments=*/ true);
+    if (!err_failing_comment.empty()) {
+        printf("Failed: %s\n", err_failing_comment.c_str());
+    } else {
+        printf("Result: %s\n", json_failing_comment.dump().c_str());
+    }
+
     std::list<int> l1 { 1, 2, 3 };
     std::vector<int> l2 { 1, 2, 3 };
     std::set<int> l3 { 1, 2, 3 };

--- a/test.cpp
+++ b/test.cpp
@@ -95,9 +95,7 @@ int main(int argc, char **argv) {
     }
 
     failing_comment_test = R"({
-      / / bad comment
-      "a": 1,
-    })";
+      / / bad comment })";
 
     json_failing_comment = Json::parse(
       failing_comment_test, err_failing_comment, /*detect_comments=*/ true);

--- a/test.cpp
+++ b/test.cpp
@@ -58,7 +58,6 @@ int main(int argc, char **argv) {
         std::cout << "    - " << k.dump() << "\n";
     }
 
-#ifdef JSON11_COMMENTS
     const string comment_test = R"({
       // comment
       "a": 1,
@@ -72,13 +71,13 @@ int main(int argc, char **argv) {
     })";
 
     string err_comment;
-    auto json_comment = Json::parse(comment_test, err_comment);
+    auto json_comment = Json::parse(
+      comment_test, err_comment, /*detect_comments=*/ true);
     if (!err_comment.empty()) {
         printf("Failed: %s\n", err_comment.c_str());
     } else {
         printf("Result: %s\n", json_comment.dump().c_str());
     }
-#endif
 
     std::list<int> l1 { 1, 2, 3 };
     std::vector<int> l2 { 1, 2, 3 };

--- a/test.cpp
+++ b/test.cpp
@@ -127,6 +127,17 @@ int main(int argc, char **argv) {
         printf("Result: %s\n", json_failing_comment.dump().c_str());
     }
 
+    failing_comment_test = R"({/* bad
+                                  comment *})";
+
+    json_failing_comment = Json::parse(
+      failing_comment_test, err_failing_comment, /*detect_comments=*/ true);
+    if (!err_failing_comment.empty()) {
+        printf("Failed: %s\n", err_failing_comment.c_str());
+    } else {
+        printf("Result: %s\n", json_failing_comment.dump().c_str());
+    }
+
     std::list<int> l1 { 1, 2, 3 };
     std::vector<int> l2 { 1, 2, 3 };
     std::set<int> l3 { 1, 2, 3 };

--- a/test.cpp
+++ b/test.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
 
     string err_comment;
     auto json_comment = Json::parse(
-      comment_test, err_comment, /*detect_comments=*/ true);
+      comment_test, err_comment, JsonParse::COMMENTS);
     if (!err_comment.empty()) {
         printf("Failed: %s\n", err_comment.c_str());
     } else {
@@ -87,7 +87,7 @@ int main(int argc, char **argv) {
 
     string err_failing_comment;
     auto json_failing_comment = Json::parse(
-      failing_comment_test, err_failing_comment, /*detect_comments=*/ true);
+      failing_comment_test, err_failing_comment, JsonParse::COMMENTS);
     if (!err_failing_comment.empty()) {
         printf("Failed: %s\n", err_failing_comment.c_str());
     } else {
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
       / / bad comment })";
 
     json_failing_comment = Json::parse(
-      failing_comment_test, err_failing_comment, /*detect_comments=*/ true);
+      failing_comment_test, err_failing_comment, JsonParse::COMMENTS);
     if (!err_failing_comment.empty()) {
         printf("Failed: %s\n", err_failing_comment.c_str());
     } else {
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
     failing_comment_test = R"({// bad comment })";
 
     json_failing_comment = Json::parse(
-      failing_comment_test, err_failing_comment, /*detect_comments=*/ true);
+      failing_comment_test, err_failing_comment, JsonParse::COMMENTS);
     if (!err_failing_comment.empty()) {
         printf("Failed: %s\n", err_failing_comment.c_str());
     } else {
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
         }/)";
 
     json_failing_comment = Json::parse(
-      failing_comment_test, err_failing_comment, /*detect_comments=*/ true);
+      failing_comment_test, err_failing_comment, JsonParse::COMMENTS);
     if (!err_failing_comment.empty()) {
         printf("Failed: %s\n", err_failing_comment.c_str());
     } else {
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
                                   comment *})";
 
     json_failing_comment = Json::parse(
-      failing_comment_test, err_failing_comment, /*detect_comments=*/ true);
+      failing_comment_test, err_failing_comment, JsonParse::COMMENTS);
     if (!err_failing_comment.empty()) {
         printf("Failed: %s\n", err_failing_comment.c_str());
     } else {

--- a/test.cpp
+++ b/test.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
     }
 
     const string comment_test = R"({
-      // comment
+      // comment /* with nested comment */
       "a": 1,
       // comment
       // continued
@@ -67,6 +67,7 @@ int main(int argc, char **argv) {
       /* multi
          line
          comment */
+      // and single-line comment
       "c": [1, 2, 3]
     })";
 


### PR DESCRIPTION
I know that comments are not defined in json standard, but many parsers do support them, and I find them useful.
the patch is activated by a preprocessor macro and the original behavior can be restored by commenting its definition.