### PR TITLE
This fixes a “No previous prototype for function” warning.

### DIFF
--- a/json11.cpp
+++ b/json11.cpp
@@ -226,12 +226,12 @@ struct Statics {
     Statics() {}
 };
 
-const Statics & statics() {
+static const Statics & statics() {
     static const Statics s {};
     return s;
 }
 
-const Json & static_null() {
+static const Json & static_null() {
     // This has to be separate, not in Statics, because Json() accesses statics().null.
     static const Json json_null;
     return json_null;


### PR DESCRIPTION
This fixes following warnings that showed up after updating json11:

<img width="314" alt="screen shot 2015-12-29 at 18 55 18" src="https://cloud.githubusercontent.com/assets/58493/12039094/ce6f1500-ae5d-11e5-9b9e-3135704faefb.png">

We run with `-Weverything` and part of this is also `-Wmissing-prototypes`. I'm not sure if that is enabled by default, but the more enabled warnings, the better!