### PR TITLE
Generate pkg-config File & Add Install Target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
+# generated files
 test
+libjson11.a
+json11.pc
+
+# Cmake
+CMakeCache.txt
+CTestTestfile.cmake
+CMakeFiles
+CMakeScripts
+cmake_install.cmake
+install_manifest.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-project(json11 CXX)
-
 cmake_minimum_required(VERSION 3.2)
+project(json11 VERSION 1.0.0 LANGUAGES CXX)
 
 enable_testing()
 
@@ -9,6 +8,11 @@ target_include_directories(json11 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_options(json11
   PUBLIC -std=c++11
   PRIVATE -fno-rtti -fno-exceptions -Wall -Wextra -Werror)
+configure_file("json11.pc.in" "json11.pc" @ONLY)
 
 add_executable(json11_test test.cpp)
 target_link_libraries(json11_test json11)
+
+install(TARGETS json11 DESTINATION lib)
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/json11.hpp" DESTINATION include)
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/json11.pc" DESTINATION lib/pkgconfig)

--- a/json11.pc.in
+++ b/json11.pc.in
@@ -1,0 +1,9 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: @PROJECT_NAME@
+Description: json11 is a tiny JSON library for C++11, providing JSON parsing and serialization.
+Version: @PROJECT_VERSION@
+Libs: -L${libdir} -ljson11
+Cflags: -I${includedir}


### PR DESCRIPTION
...to the CMake build script. The pkg-config file needs a version number (which
it takes from the CMakeLists.txt variable), which I've set to 1.0.0. The cmake
project declaration needs to be after the minimum-requirement declaration to
avoid errors from the cmake's change in VERSION semantics.