### PR TITLE
Parse half ready json

### DIFF
--- a/json11.cpp
+++ b/json11.cpp
@@ -733,15 +733,18 @@ Json Json::parse(const string &in, string &err, JsonParse strategy) {
 
 // Documented in json11.hpp
 vector<Json> Json::parse_multi(const string &in,
+                               std::string::size_type &parser_stop_pos,
                                string &err,
                                JsonParse strategy) {
     JsonParser parser { in, 0, err, false, strategy };
-
+    parser_stop_pos = 0;
     vector<Json> json_vec;
     while (parser.i != in.size() && !parser.failed) {
         json_vec.push_back(parser.parse_json(0));
         // Check for another object
         parser.consume_garbage();
+        if (!parser.failed)
+            parser_stop_pos = parser.i;
     }
     return json_vec;
 }

--- a/json11.hpp
+++ b/json11.hpp
@@ -165,8 +165,17 @@ public:
     // Parse multiple objects, concatenated or separated by whitespace
     static std::vector<Json> parse_multi(
         const std::string & in,
+        std::string::size_type & parser_stop_pos,
         std::string & err,
         JsonParse strategy = JsonParse::STANDARD);
+
+    static inline std::vector<Json> parse_multi(
+        const std::string & in,
+        std::string & err,
+        JsonParse strategy = JsonParse::STANDARD) {
+        std::string::size_type parser_stop_pos;
+        return parse_multi(in, parser_stop_pos, err, strategy);
+    }
 
     bool operator== (const Json &rhs) const;
     bool operator<  (const Json &rhs) const;


### PR DESCRIPTION
This patch (pull request) add ability to parse half ready json.
For example if you recieve json stream from network, you can get
something like this
```javascript
{"k1" : "v1"}
{"k2": 
```
you get one full json entry,  and half of next one.

At now `json11` can parse `{"k1" : "v1"}` and give up on `{"k2": ` - great.
But `json11` not return updated position in input, so it is not possible to remove `{"k1" : "v1"}`
from internal buffer and wait for new data.
This pull request solve this inconvenience.