### PR TITLE
make JsonParser invisible from outside

### DIFF
--- a/json11.cpp
+++ b/json11.cpp
@@ -326,11 +326,12 @@ static inline bool in_range(long x, long lower, long upper) {
     return (x >= lower && x <= upper);
 }
 
+namespace {
 /* JsonParser
  *
  * Object that tracks all state of an in-progress parse.
  */
-struct JsonParser {
+struct JsonParser final {
 
     /* State
      */
@@ -718,6 +719,7 @@ struct JsonParser {
         return fail("expected value, got " + esc(ch));
     }
 };
+}//namespace {
 
 Json Json::parse(const string &in, string &err, JsonParse strategy) {
     JsonParser parser { in, 0, err, false, strategy };


### PR DESCRIPTION
`JsonParser` is not visible from outside of `json11.cpp`, 
so it has sense to move it into anonymous namespace to hint compiler that more strong optimizations are  possible . `gcc 5.2` not give any visible performance gains (~1%),
but  with this patch change size of library (`.text` section) on gcc/linux was reduceded by 5%.