### PR TITLE
Don't assume in-tree builds when installing json11.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,4 +15,4 @@ target_link_libraries(json11_test json11)
 
 install(TARGETS json11 DESTINATION lib)
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/json11.hpp" DESTINATION include)
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/json11.pc" DESTINATION lib/pkgconfig)
+install(FILES "${CMAKE_BINARY_DIR}/json11.pc" DESTINATION lib/pkgconfig)


### PR DESCRIPTION
The existing implementation attempts to install `json11.pc` from `CMAKE_CURRENT_SOURCE_DIRECTORY`. That only works if you are doing an in-tree build: not a great idea at the best of times, what with it cluttering up your source control with build artefacts.

This patch makes the build system cease to be sensitive to the location of the cmake binary directory.