### PR TITLE
Add option to disable unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(json11 VERSION 1.0.0 LANGUAGES CXX)
 
 enable_testing()
 
+option(JSON11_BUILD_TESTS "Build unit tests" ON)
+
 add_library(json11 json11.cpp)
 target_include_directories(json11 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_options(json11
@@ -10,8 +12,10 @@ target_compile_options(json11
   PRIVATE -fno-rtti -fno-exceptions -Wall -Wextra -Werror)
 configure_file("json11.pc.in" "json11.pc" @ONLY)
 
-add_executable(json11_test test.cpp)
-target_link_libraries(json11_test json11)
+if (JSON11_BUILD_TESTS)
+  add_executable(json11_test test.cpp)
+  target_link_libraries(json11_test json11)
+endif()
 
 install(TARGETS json11 DESTINATION lib)
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/json11.hpp" DESTINATION include)


### PR DESCRIPTION
This PR make the unit tests optional.

By default the unit tests are still enabled, so It's backwards compatible.

This fixes this problem when integrating this library using CMake on iOS.
http://stackoverflow.com/questions/37880180/error-creating-ios-static-library-using-cmake