### PR TITLE
Allow json11 tests to be customized with pre-processor defines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
+# Environment variable to enable or disable code which demonstrates the behavior change
+# in Xcode 7 / Clang 3.7, introduced by DR1467 and described here:
+# https://llvm.org/bugs/show_bug.cgi?id=23812
+# Defaults to on in order to act as a warning to anyone who's unaware of the issue.
+ifneq ($(JSON11_ENABLE_DR1467_CANARY),)
+CANARY_ARGS = -DJSON11_ENABLE_DR1467_CANARY=$(JSON11_ENABLE_DR1467_CANARY)
+endif
+
 test: json11.cpp json11.hpp test.cpp
-	$(CXX) -O -std=c++11 json11.cpp test.cpp -o test -fno-rtti -fno-exceptions
+	$(CXX) $(CANARY_ARGS) -O -std=c++11 json11.cpp test.cpp -o test -fno-rtti -fno-exceptions
 
 clean:
 	if [ -e test ]; then rm test; fi

--- a/test.cpp
+++ b/test.cpp
@@ -1,6 +1,33 @@
+/*
+ * Define JSON11_TEST_CUSTOM_CONFIG to 1 if you want to build this tester into
+ * your own unit-test framework rather than a stand-alone program.  By setting
+ * The values of the variables included below, you can insert your own custom
+ * code into this file as it builds, in order to make it into a test case for
+ * your favorite framework.
+ */
+#if(!JSON11_TEST_CUSTOM_CONFIG)
+#define JSON11_TEST_CPP_PREFIX_CODE
+#define JSON11_TEST_CPP_SUFFIX_CODE
+#define JSON11_TEST_STANDALONE_MAIN 1
+#define JSON11_TEST_CASE(name) static void name()
+#define JSON11_TEST_ASSERT(b) assert(b)
 #ifdef NDEBUG
 #undef NDEBUG//at now assert will work even in Release build
 #endif
+#endif // JSON11_TEST_CUSTOM_CONFIG
+
+/*
+ * Enable or disable code which demonstrates the behavior change in Xcode 7 / Clang 3.7,
+ * introduced by DR1467 and described here: https://llvm.org/bugs/show_bug.cgi?id=23812
+ * Defaults to on in order to act as a warning to anyone who's unaware of the issue.
+ */
+#ifndef JSON11_ENABLE_DR1467_CANARY
+#define JSON11_ENABLE_DR1467_CANARY 1
+#endif
+
+/*
+ * Beginning of standard source file, which makes use of the customizations above.
+ */
 #include <cassert>
 #include <string>
 #include <cstdio>
@@ -12,12 +39,16 @@
 #include <set>
 #include <unordered_map>
 #include <algorithm>
+#include <type_traits>
+
+// Insert user-defined prefix code (includes, function declarations, etc)
+// to set up a custom test suite
+JSON11_TEST_CPP_PREFIX_CODE
 
 using namespace json11;
 using std::string;
 
 // Check that Json has the properties we want.
-#include <type_traits>
 #define CHECK_TRAIT(x) static_assert(std::x::value, #x)
 CHECK_TRAIT(is_nothrow_constructible<Json>);
 CHECK_TRAIT(is_nothrow_default_constructible<Json>);
@@ -27,28 +58,7 @@ CHECK_TRAIT(is_copy_assignable<Json>);
 CHECK_TRAIT(is_nothrow_move_assignable<Json>);
 CHECK_TRAIT(is_nothrow_destructible<Json>);
 
-void parse_from_stdin() {
-    string buf;
-    string line;
-    while (std::getline(std::cin, line)) {
-        buf += line + "\n";
-    }
-
-    string err;
-    auto json = Json::parse(buf, err);
-    if (!err.empty()) {
-        printf("Failed: %s\n", err.c_str());
-    } else {
-        printf("Result: %s\n", json.dump().c_str());
-    }
-}
-
-int main(int argc, char **argv) {
-    if (argc == 2 && argv[1] == string("--stdin")) {
-        parse_from_stdin();
-        return 0;
-    }
-
+JSON11_TEST_CASE(json11_test) {
     const string simple_test =
         R"({"k1":"v1", "k2":42, "k3":["a",123,true,false,null]})";
 
@@ -146,12 +156,12 @@ int main(int argc, char **argv) {
     std::list<int> l1 { 1, 2, 3 };
     std::vector<int> l2 { 1, 2, 3 };
     std::set<int> l3 { 1, 2, 3 };
-    assert(Json(l1) == Json(l2));
-    assert(Json(l2) == Json(l3));
+    JSON11_TEST_ASSERT(Json(l1) == Json(l2));
+    JSON11_TEST_ASSERT(Json(l2) == Json(l3));
 
     std::map<string, string> m1 { { "k1", "v1" }, { "k2", "v2" } };
     std::unordered_map<string, string> m2 { { "k1", "v1" }, { "k2", "v2" } };
-    assert(Json(m1) == Json(m2));
+    JSON11_TEST_ASSERT(Json(m1) == Json(m2));
 
     // Json literals
     Json obj = Json::object({
@@ -162,13 +172,13 @@ int main(int argc, char **argv) {
 
     std::cout << "obj: " << obj.dump() << "\n";
 
-    assert(Json("a").number_value() == 0);
-    assert(Json("a").string_value() == "a");
-    assert(Json().number_value() == 0);
+    JSON11_TEST_ASSERT(Json("a").number_value() == 0);
+    JSON11_TEST_ASSERT(Json("a").string_value() == "a");
+    JSON11_TEST_ASSERT(Json().number_value() == 0);
 
-    assert(obj == json);
-    assert(Json(42) == Json(42.0));
-    assert(Json(42) != Json(42.1));
+    JSON11_TEST_ASSERT(obj == json);
+    JSON11_TEST_ASSERT(Json(42) == Json(42.0));
+    JSON11_TEST_ASSERT(Json(42) != Json(42.1));
 
     const string unicode_escape_test =
         R"([ "blah\ud83d\udca9blah\ud83dblah\udca9blah\u0000blah\u1234" ])";
@@ -177,18 +187,17 @@ int main(int argc, char **argv) {
                         "\xed\xb2\xa9" "blah" "\0" "blah" "\xe1\x88\xb4";
 
     Json uni = Json::parse(unicode_escape_test, err);
-    assert(uni[0].string_value().size() == (sizeof utf8) - 1);
-    assert(std::memcmp(uni[0].string_value().data(), utf8, sizeof utf8) == 0);
+    JSON11_TEST_ASSERT(uni[0].string_value().size() == (sizeof utf8) - 1);
+    JSON11_TEST_ASSERT(std::memcmp(uni[0].string_value().data(), utf8, sizeof utf8) == 0);
 
     // Demonstrates the behavior change in Xcode 7 / Clang 3.7, introduced by DR1467
     // and described here: https://llvm.org/bugs/show_bug.cgi?id=23812
-    const bool ENABLE_DR1467_CANARY = true; // Allow easy disabling for users who work around it.
-    if (ENABLE_DR1467_CANARY) {
+    if (JSON11_ENABLE_DR1467_CANARY) {
         Json nested_array = Json::array { Json::array { 1, 2, 3 } };
-        assert(nested_array.is_array());
-        assert(nested_array.array_items().size() == 1);
-        assert(nested_array.array_items()[0].is_array());
-        assert(nested_array.array_items()[0].array_items().size() == 3);
+        JSON11_TEST_ASSERT(nested_array.is_array());
+        JSON11_TEST_ASSERT(nested_array.array_items().size() == 1);
+        JSON11_TEST_ASSERT(nested_array.array_items()[0].is_array());
+        JSON11_TEST_ASSERT(nested_array.array_items()[0].array_items().size() == 3);
     }
 
     {
@@ -211,13 +220,13 @@ int main(int argc, char **argv) {
             std::string::size_type parser_stop_pos;
             std::string err;
             auto res = Json::parse_multi(tst.input, parser_stop_pos, err);
-            assert(parser_stop_pos == tst.expect_parser_stop_pos);
-            assert(
+            JSON11_TEST_ASSERT(parser_stop_pos == tst.expect_parser_stop_pos);
+            JSON11_TEST_ASSERT(
                 (size_t)std::count_if(res.begin(), res.end(),
                                       [](const Json& j) { return !j.is_null(); })
                 == tst.expect_not_empty_elms_count);
             if (!res.empty()) {
-                assert(tst.expect_parse_res == res[0]);
+                JSON11_TEST_ASSERT(tst.expect_parse_res == res[0]);
             }
         }
     }
@@ -241,3 +250,36 @@ int main(int argc, char **argv) {
     std::string points_json = Json(points).dump();
     printf("%s\n", points_json.c_str());
 }
+
+#if(JSON11_TEST_STANDALONE_MAIN)
+
+static void parse_from_stdin() {
+    string buf;
+    string line;
+    while (std::getline(std::cin, line)) {
+        buf += line + "\n";
+    }
+
+    string err;
+    auto json = Json::parse(buf, err);
+    if (!err.empty()) {
+        printf("Failed: %s\n", err.c_str());
+    } else {
+        printf("Result: %s\n", json.dump().c_str());
+    }
+}
+
+int main(int argc, char **argv) {
+    if (argc == 2 && argv[1] == string("--stdin")) {
+        parse_from_stdin();
+        return 0;
+    }
+
+    json11_test();
+}
+
+#endif // JSON11_TEST_STANDALONE_MAIN
+
+// Insert user-defined suffix code (function definitions, etc)
+// to set up a custom test suite
+JSON11_TEST_CPP_SUFFIX_CODE

--- a/test.cpp
+++ b/test.cpp
@@ -5,7 +5,7 @@
  * code into this file as it builds, in order to make it into a test case for
  * your favorite framework.
  */
-#if(!JSON11_TEST_CUSTOM_CONFIG)
+#if !JSON11_TEST_CUSTOM_CONFIG
 #define JSON11_TEST_CPP_PREFIX_CODE
 #define JSON11_TEST_CPP_SUFFIX_CODE
 #define JSON11_TEST_STANDALONE_MAIN 1
@@ -251,7 +251,7 @@ JSON11_TEST_CASE(json11_test) {
     printf("%s\n", points_json.c_str());
 }
 
-#if(JSON11_TEST_STANDALONE_MAIN)
+#if JSON11_TEST_STANDALONE_MAIN
 
 static void parse_from_stdin() {
     string buf;


### PR DESCRIPTION
This allows json11's test.cpp to be customized in order to make it fit into a specific testing framework, without making any particular framework a default dependency.  The configuration is via pre-processor defines, which can disable the main() function and replace various code snippets.  At Dropbox, I'm using this to turn test.cpp into a gtest test, but others can use their favorite framework.

I also made the DR1467 canary configurable in the same way, as well as from the command-line to make.

I'm putting this up as a PR so @j4cbo can comment before I merge.
