### PR TITLE
Use CXX_STANDARD to specify c++11 compile flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,12 @@ enable_testing()
 
 option(JSON11_BUILD_TESTS "Build unit tests" ON)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_library(json11 json11.cpp)
 target_include_directories(json11 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_options(json11
-  PUBLIC -std=c++11
   PRIVATE -fno-rtti -fno-exceptions -Wall -Wextra -Werror)
 configure_file("json11.pc.in" "json11.pc" @ONLY)
 


### PR DESCRIPTION
Uses [CXX_STANDARD](https://cmake.org/cmake/help/v3.1/prop_tgt/CXX_STANDARD.html#prop_tgt:CXX_STANDARD) to specify a C++11 build, which avoids issues when a build contains C files.

Fixes #70 

The tests seem to fail on my laptop, with or without this change (same output)

```
build ▹ ./json11_test
k1: v1
k3: ["a", 123, true, false, null]
    - "a"
    - 123
    - true
    - false
    - null
Result: {"a": 1, "b": "text", "c": [1, 2, 3]}
Result: {}
Failed: malformed comment
Failed: unexpected end of input inside inline comment
Failed: unexpected end of input inside comment
Failed: unexpected end of input inside multi-line comment
obj: {"k1": "v1", "k2": 42, "k3": ["a", 123, true, false, null]}
Assertion failed: (nested_array.array_items().size() == 1), function json11_test, file /Users/adam/workspace/json11/test.cpp, line 198.
Abort trap: 6
```