### PR TITLE
Add cmake option for DR1467 canary tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(json11 VERSION 1.0.0 LANGUAGES CXX)
 enable_testing()
 
 option(JSON11_BUILD_TESTS "Build unit tests" ON)
+option(JSON11_ENABLE_DR1467_CANARY "Enable canary test for DR 1467" ON)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -16,6 +17,14 @@ target_compile_options(json11
 configure_file("json11.pc.in" "json11.pc" @ONLY)
 
 if (JSON11_BUILD_TESTS)
+
+  # enable test for DR1467, described here: https://llvm.org/bugs/show_bug.cgi?id=23812
+  if(JSON11_ENABLE_DR1467_CANARY)
+    add_definitions(-D JSON11_ENABLE_DR1467_CANARY=1)
+  else()
+    add_definitions(-D JSON11_ENABLE_DR1467_CANARY=0)
+  endif()
+
   add_executable(json11_test test.cpp)
   target_link_libraries(json11_test json11)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(json11 VERSION 1.0.0 LANGUAGES CXX)
 enable_testing()
 
 option(JSON11_BUILD_TESTS "Build unit tests" ON)
-option(JSON11_ENABLE_DR1467_CANARY "Enable canary test for DR 1467" ON)
+option(JSON11_ENABLE_DR1467_CANARY "Enable canary test for DR 1467" OFF)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
This PR adds a cmake option for the DR 1467 tests, [as described](https://github.com/dropbox/json11/pull/71#issuecomment-239075354) in PR #71 

That said, the test output seems to be the same regardless. This is the output after applying this PR, with an extra debug line printed in [the relevant canary section of the tests](https://github.com/dropbox/json11/blob/787809178ddb3d739e6f408af5233930c9077929/test.cpp#L195-L201)

```
adam@adam-xps:~/workspace/json11/build$ cmake ..
-- The CXX compiler identification is GNU 5.4.0
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/adam/workspace/json11/build
adam@adam-xps:~/workspace/json11/build$ make
Scanning dependencies of target json11
[ 25%] Building CXX object CMakeFiles/json11.dir/json11.cpp.o
[ 50%] Linking CXX static library libjson11.a
[ 50%] Built target json11
Scanning dependencies of target json11_test
[ 75%] Building CXX object CMakeFiles/json11_test.dir/test.cpp.o
[100%] Linking CXX executable json11_test
[100%] Built target json11_test
adam@adam-xps:~/workspace/json11/build$ ./json11_test
k1: v1
k3: ["a", 123, true, false, null]
    - "a"
    - 123
    - true
    - false
    - null
Result: {"a": 1, "b": "text", "c": [1, 2, 3]}
Result: {}
Failed: malformed comment
Failed: unexpected end of input inside inline comment
Failed: unexpected end of input inside comment
Failed: unexpected end of input inside multi-line comment
obj: {"k1": "v1", "k2": 42, "k3": ["a", 123, true, false, null]}
-- performing canary test for DR1467
{"key1": "value1", "key2": false, "key3": [1, 2, 3]}
[[1, 2], [10, 20], [100, 200]]
adam@adam-xps:~/workspace/json11/build$ cmake -D JSON11_ENABLE_DR1467_CANARY=off ..
-- Configuring done
-- Generating done
-- Build files have been written to: /home/adam/workspace/json11/build
adam@adam-xps:~/workspace/json11/build$ make
[ 25%] Building CXX object CMakeFiles/json11.dir/json11.cpp.o
[ 50%] Linking CXX static library libjson11.a
[ 50%] Built target json11
[ 75%] Building CXX object CMakeFiles/json11_test.dir/test.cpp.o
[100%] Linking CXX executable json11_test
[100%] Built target json11_test
adam@adam-xps:~/workspace/json11/build$ ./json11_test
k1: v1
k3: ["a", 123, true, false, null]
    - "a"
    - 123
    - true
    - false
    - null
Result: {"a": 1, "b": "text", "c": [1, 2, 3]}
Result: {}
Failed: malformed comment
Failed: unexpected end of input inside inline comment
Failed: unexpected end of input inside comment
Failed: unexpected end of input inside multi-line comment
obj: {"k1": "v1", "k2": 42, "k3": ["a", 123, true, false, null]}
-- NOT performing canary test for DR1467
{"key1": "value1", "key2": false, "key3": [1, 2, 3]}
[[1, 2], [10, 20], [100, 200]]
```
