### PR TITLE
CMakeLists: avoid LD errors, use -fPIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,10 @@ option(JSON11_BUILD_TESTS "Build unit tests" ON)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_INSTALL_PREFIX /usr)
 
 add_library(json11 json11.cpp)
-target_include_directories(json11 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(json11 PUBLIC ${CMAKE_SOURCE_DIR})
 target_compile_options(json11
   PRIVATE -fPIC -fno-rtti -fno-exceptions -Wall -Wextra -Werror)
 configure_file("json11.pc.in" "json11.pc" @ONLY)
@@ -19,6 +20,6 @@ if (JSON11_BUILD_TESTS)
   target_link_libraries(json11_test json11)
 endif()
 
-install(TARGETS json11 DESTINATION lib)
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/json11.hpp" DESTINATION include)
-install(FILES "${CMAKE_BINARY_DIR}/json11.pc" DESTINATION lib/pkgconfig)
+install(TARGETS json11 DESTINATION lib/${CMAKE_LIBRARY_ARCHITECTURE})
+install(FILES "${CMAKE_SOURCE_DIR}/json11.hpp" DESTINATION include/${CMAKE_LIBRARY_ARCHITECTURE})
+install(FILES "${CMAKE_BINARY_DIR}/json11.pc" DESTINATION lib/${CMAKE_LIBRARY_ARCHITECTURE}/pkgconfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_library(json11 json11.cpp)
 target_include_directories(json11 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_options(json11
-  PRIVATE -fno-rtti -fno-exceptions -Wall -Wextra -Werror)
+  PRIVATE -fPIC -fno-rtti -fno-exceptions -Wall -Wextra -Werror)
 configure_file("json11.pc.in" "json11.pc" @ONLY)
 
 if (JSON11_BUILD_TESTS)

--- a/json11.pc.in
+++ b/json11.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${prefix}/lib
-includedir=${prefix}/include
+libdir=${prefix}/lib/@CMAKE_LIBRARY_ARCHITECTURE@
+includedir=${prefix}/include/@CMAKE_LIBRARY_ARCHITECTURE@
 
 Name: @PROJECT_NAME@
 Description: json11 is a tiny JSON library for C++11, providing JSON parsing and serialization.


### PR DESCRIPTION
library should be compiled as position independent code
