### PR TITLE
Fixed a type conversion warning

### DIFF
--- a/json11.cpp
+++ b/json11.cpp
@@ -435,7 +435,7 @@ struct JsonParser final {
     char get_next_token() {
         consume_garbage();
         if (i == str.size())
-            return fail("unexpected end of input", 0);
+            return (char)fail("unexpected end of input", 0);
 
         return str[i++];
     }

--- a/json11.cpp
+++ b/json11.cpp
@@ -435,7 +435,7 @@ struct JsonParser final {
     char get_next_token() {
         consume_garbage();
         if (i == str.size())
-            return (char)fail("unexpected end of input", 0);
+            return fail("unexpected end of input", (char)0);
 
         return str[i++];
     }


### PR DESCRIPTION
This gave a warning in g++ 4.7.3.