### PR TITLE
don't override CMAKE_INSTALL_PREFIX if specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,9 @@ option(JSON11_ENABLE_DR1467_CANARY "Enable canary test for DR 1467" OFF)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_INSTALL_PREFIX /usr)
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX /usr)
+endif()
 
 add_library(json11 json11.cpp)
 target_include_directories(json11 PUBLIC ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
Per http://stackoverflow.com/a/39485990/42543, if the user does `cmake .  -DCMAKE_INSTALL_PREFIX=/usr/somewhere-else` then respect that.