### PR TITLE
Fix MSVC Compilation: Add MSVC warning flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,13 +18,14 @@ target_compile_options(json11
   PRIVATE -fPIC -fno-rtti -fno-exceptions -Wall)
 
 # Set warning flags, which may vary per platform
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_compile_options(json11
-    PRIVATE /W4 /WX)
-else()
-  target_compile_options(json11
-    PRIVATE -Wextra -Werror)
-endif()
+include(CheckCXXCompilerFlag)
+set(_possible_warnings_flags /W4 /WX -Wextra -Werror)
+foreach(_warning_flag in ${_possible_warnings_flags})
+  CHECK_CXX_COMPILER_FLAG(_warning_flag _flag_supported)
+  if(${_flag_supported})
+    target_compile_options(json11 PRIVATE ${_warning_flag})
+  endif()
+endforeach()
 
 configure_file("json11.pc.in" "json11.pc" @ONLY)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,17 @@ endif()
 add_library(json11 json11.cpp)
 target_include_directories(json11 PUBLIC ${CMAKE_SOURCE_DIR})
 target_compile_options(json11
-  PRIVATE -fPIC -fno-rtti -fno-exceptions -Wall -Wextra -Werror)
+  PRIVATE -fPIC -fno-rtti -fno-exceptions -Wall)
+
+# Set warning flags, which may vary per platform
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  target_compile_options(json11
+    PRIVATE /W4 /WX)
+else()
+  target_compile_options(json11
+    PRIVATE -Wextra -Werror)
+endif()
+
 configure_file("json11.pc.in" "json11.pc" @ONLY)
 
 if (JSON11_BUILD_TESTS)


### PR DESCRIPTION
When trying to build JSON11 on Microsoft Visual Studio 14 2015, the compiler would complain about the `-Wextra` and `-Werror` flags.

This PR adds a check for the C++ compiler before adding the compiler specific flags