### PR TITLE
Disable build tests by default in CMake and enable them in make file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(json11 VERSION 1.0.0 LANGUAGES CXX)
 
 enable_testing()
 
-option(JSON11_BUILD_TESTS "Build unit tests" ON)
+option(JSON11_BUILD_TESTS "Build unit tests" OFF)
 option(JSON11_ENABLE_DR1467_CANARY "Enable canary test for DR 1467" OFF)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,12 @@ ifneq ($(JSON11_ENABLE_DR1467_CANARY),)
 CANARY_ARGS = -DJSON11_ENABLE_DR1467_CANARY=$(JSON11_ENABLE_DR1467_CANARY)
 endif
 
+ifneq ($(JSON11_BUILD_TESTS),)
+JSON11_BUILD_TESTS_ARGS = -DJSON11_BUILD_TESTS=$(JSON11_BUILD_TESTS)
+endif
+
 test: json11.cpp json11.hpp test.cpp
-	$(CXX) $(CANARY_ARGS) -O -std=c++11 json11.cpp test.cpp -o test -fno-rtti -fno-exceptions
+	$(CXX) $(CANARY_ARGS) $(JSON11_BUILD_TESTS_ARGS) -O -std=c++11 json11.cpp test.cpp -o test -fno-rtti -fno-exceptions
 
 clean:
 	if [ -e test ]; then rm test; fi

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,8 @@ ifneq ($(JSON11_ENABLE_DR1467_CANARY),)
 CANARY_ARGS = -DJSON11_ENABLE_DR1467_CANARY=$(JSON11_ENABLE_DR1467_CANARY)
 endif
 
-ifneq ($(JSON11_BUILD_TESTS),)
-JSON11_BUILD_TESTS_ARGS = -DJSON11_BUILD_TESTS=$(JSON11_BUILD_TESTS)
-endif
-
 test: json11.cpp json11.hpp test.cpp
-	$(CXX) $(CANARY_ARGS) $(JSON11_BUILD_TESTS_ARGS) -O -std=c++11 json11.cpp test.cpp -o test -fno-rtti -fno-exceptions
+	$(CXX) $(CANARY_ARGS) -O -std=c++11 json11.cpp test.cpp -o test -fno-rtti -fno-exceptions
 
 clean:
 	if [ -e test ]; then rm test; fi


### PR DESCRIPTION
This PR disable tests in the `CMakeLists.txt` and enable them in the `Makefile` with the option `JSON11_BUILD_TESTS `.

This will make the integration of json11 on other projects with CMake easier, especially on iOS, since it crashes it the tests are enabled. 
http://stackoverflow.com/questions/37880180/error-creating-ios-static-library-using-cmake