### PR TITLE
operator== could be faster by checking node identity

### DIFF
--- a/json11.cpp
+++ b/json11.cpp
@@ -300,15 +300,17 @@ const Json & JsonArray::operator[] (size_t i) const {
  */
 
 bool Json::operator== (const Json &other) const {
-    if (m_ptr->type() != other.m_ptr->type())
-        return false;
     if (m_ptr == other.m_ptr)
         return true;
+    if (m_ptr->type() != other.m_ptr->type())
+        return false;
 
     return m_ptr->equals(other.m_ptr.get());
 }
 
 bool Json::operator< (const Json &other) const {
+    if (m_ptr == other.m_ptr)
+        return false;
     if (m_ptr->type() != other.m_ptr->type())
         return m_ptr->type() < other.m_ptr->type();
 

--- a/json11.cpp
+++ b/json11.cpp
@@ -302,6 +302,8 @@ const Json & JsonArray::operator[] (size_t i) const {
 bool Json::operator== (const Json &other) const {
     if (m_ptr->type() != other.m_ptr->type())
         return false;
+    if (m_ptr == other.m_ptr)
+        return true;
 
     return m_ptr->equals(other.m_ptr.get());
 }


### PR DESCRIPTION
# Story

When comparing two nodes we can speed up use cases where we reuse node instances partially or totally:

```cpp
Json my_json = Json::object {
    { "key1", "value1" },
    { "key2", false },
    { "key3", Json::array { 1, 2, 3 } },
};
auto my_other_json = my_json;
if (my_json == my_other_json)
{
    ...
}
```

Two nodes sharing a portion of nodes:

```
Json common = Json::object {
    { "key1", "value1" },
    { "key2", false },
    { "key3", Json::array { 1, 2, 3 } },
};
Json a = Son::object {
    { "common", common },
    { "extra value", "value1" }
}
Json b = Son::object {
    { "common", common },
    { "extra value", "value1" }
}
if (a == b) {
    ...
}
```

It may be useful to apply the same concept also for `operator<`, in such case would always return `false`:

```cpp
bool Json::operator< (const Json &other) const {
    if (m_ptr == other.m_ptr)
        return false;
    if (m_ptr->type() != other.m_ptr->type())
        return m_ptr->type() < other.m_ptr->type();
    return m_ptr->less(other.m_ptr.get());
}
```

These little changes would open memory + CPU optimisations of this sort:

```cpp
Json reuse_instances(Json new_node)
{
   static std::set<Json> known_values;

   auto it = used_values.find(new_node);
   if (it != used_values.end()) {
       return it->second;
   }

   // may recursively do this for member nodes of object and arrays
   ...

   known_values.insert(new_node);
   return node;
}

...

Json my_object = reuse_instances(Json(Json::object {
    { "key1", "value1" },
    { "key2", false },
    { "key3", Json::array { 1, 2, 3 } },
}));
```

 
