### PR TITLE
[WIP - Do not pull] Switch off compiler errors for floating point value comparison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CANARY_ARGS = -DJSON11_ENABLE_DR1467_CANARY=$(JSON11_ENABLE_DR1467_CANARY)
 endif
 
 test: json11.cpp json11.hpp test.cpp
-	$(CXX) $(CANARY_ARGS) -O -std=c++11 json11.cpp test.cpp -o test -fno-rtti -fno-exceptions
+	$(CXX) $(CANARY_ARGS) -Wfloat-equal -O -std=c++11 json11.cpp test.cpp -o test -fno-rtti -fno-exceptions 
 
 clean:
 	if [ -e test ]; then rm test; fi

--- a/json11.cpp
+++ b/json11.cpp
@@ -19,6 +19,14 @@
  * THE SOFTWARE.
  */
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#elif defined(__GNUC__) || defined(__GNUG__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+
 #include "json11.hpp"
 #include <cassert>
 #include <cmath>
@@ -782,3 +790,9 @@ bool Json::has_shape(const shape & types, string & err) const {
 }
 
 } // namespace json11
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) || defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif

--- a/json11.hpp
+++ b/json11.hpp
@@ -68,6 +68,14 @@
     #endif
 #endif
 
+//#if defined(__clang__)
+//#pragma clang diagnostic push
+//#pragma clang diagnostic ignored "-Wfloat-equal"
+//#elif defined(__GNUC__) || defined(__GNUG__)
+//#pragma GCC diagnostic push
+//#pragma GCC diagnostic ignored "-Wfloat-equal"
+//#endif
+
 namespace json11 {
 
 enum JsonParse {
@@ -230,3 +238,10 @@ protected:
 };
 
 } // namespace json11
+
+
+//#if defined(__clang__)
+//#pragma clang diagnostic pop
+//#elif defined(__GNUC__) || defined(__GNUG__)
+//#pragma GCC diagnostic pop
+//#endif

--- a/test.cpp
+++ b/test.cpp
@@ -26,6 +26,14 @@
 #define JSON11_ENABLE_DR1467_CANARY 0
 #endif
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wfloat-equal"
+#elif defined(__GNUC__) || defined(__GNUG__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#endif
+
 /*
  * Beginning of standard source file, which makes use of the customizations above.
  */
@@ -279,3 +287,10 @@ int main(int argc, char **argv) {
 // Insert user-defined suffix code (function definitions, etc)
 // to set up a custom test suite
 JSON11_TEST_CPP_SUFFIX_CODE
+
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__) || defined(__GNUG__)
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
Work in progress - Do not pull

Does:
#pragma <compiler> diagnostic push
#pragma <compiler> diagnostic ignored "-Wfloat-equal"
...code...
#pragma <compiler> diagnostic pop

Works nicely in target project when this is wrapped around json11.cpp only
When building test.cpp it needs to go in json11.ccp and test.cpp

Not the clean solution desired.