### PR TITLE
add decimal support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,7 @@ endif()
 
 add_library(json11 json11.cpp)
 target_include_directories(json11 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_compile_options(json11
-  PRIVATE -fPIC -fno-rtti -fno-exceptions -Wall)
+target_compile_options(json11 PRIVATE -fPIC  -Wall)
 
 # Set warning flags, which may vary per platform
 include(CheckCXXCompilerFlag)
@@ -40,6 +39,10 @@ endforeach()
 configure_file("json11.pc.in" "json11.pc" @ONLY)
 
 if (JSON11_BUILD_TESTS)
+
+  set(Boost_USE_STATIC_LIBS ON)
+  find_package(Boost 1.55 REQUIRED system exception)
+  target_link_libraries(json11 Boost::system Boost::exception)
 
   # enable test for DR1467, described here: https://llvm.org/bugs/show_bug.cgi?id=23812
   if(JSON11_ENABLE_DR1467_CANARY)

--- a/json11.hpp
+++ b/json11.hpp
@@ -55,6 +55,7 @@
 #include <map>
 #include <memory>
 #include <initializer_list>
+#include <boost/multiprecision/cpp_dec_float.hpp>
 
 #ifdef _MSC_VER
     #if _MSC_VER <= 1800 // VS 2013
@@ -69,6 +70,16 @@
 #endif
 
 namespace json11 {
+
+using decimal = boost::multiprecision::cpp_dec_float_50;
+
+inline std::string decimal_to_string(const decimal& value)
+{
+	std::stringstream os;
+	os.precision(std::numeric_limits<decimal>::max_digits10);  // Ensure all potentially significant bits are output.
+	os << value;
+	return os.str();
+}
 
 enum JsonParse {
     STANDARD, COMMENTS
@@ -91,6 +102,7 @@ public:
     Json() noexcept;                // NUL
     Json(std::nullptr_t) noexcept;  // NUL
     Json(double value);             // NUMBER
+    Json(decimal value);            // NUMBER
     Json(int value);                // NUMBER
     Json(bool value);               // BOOL
     Json(const std::string &value); // STRING
@@ -135,7 +147,7 @@ public:
     // Return the enclosed value if this is a number, 0 otherwise. Note that json11 does not
     // distinguish between integer and non-integer numbers - number_value() and int_value()
     // can both be applied to a NUMBER-typed object.
-    double number_value() const;
+    decimal number_value() const;
     int int_value() const;
 
     // Return the enclosed value if this is a boolean, false otherwise.
@@ -218,7 +230,7 @@ protected:
     virtual bool equals(const JsonValue * other) const = 0;
     virtual bool less(const JsonValue * other) const = 0;
     virtual void dump(std::string &out) const = 0;
-    virtual double number_value() const;
+    virtual decimal number_value() const;
     virtual int int_value() const;
     virtual bool bool_value() const;
     virtual const std::string &string_value() const;

--- a/test.cpp
+++ b/test.cpp
@@ -61,7 +61,7 @@ CHECK_TRAIT(is_nothrow_destructible<Json>);
 
 JSON11_TEST_CASE(json11_test) {
     const string simple_test =
-        R"({"k1":"v1", "k2":42, "k3":["a",123,true,false,null]})";
+        R"({"k1":"v1", "k2":42, "k3":["a",123.123,true,false,null]})";
 
     string err;
     const auto json = Json::parse(simple_test, err);
@@ -158,20 +158,20 @@ JSON11_TEST_CASE(json11_test) {
     // Json literals
     const Json obj = Json::object({
         { "k1", "v1" },
-        { "k2", 42.0 },
-        { "k3", Json::array({ "a", 123.0, true, false, nullptr }) },
+        { "k2", json11::decimal(42.0) },
+        { "k3", Json::array({ "a", json11::decimal("123.123"), true, false, nullptr }) },
     });
 
     std::cout << "obj: " << obj.dump() << "\n";
-    JSON11_TEST_ASSERT(obj.dump() == "{\"k1\": \"v1\", \"k2\": 42, \"k3\": [\"a\", 123, true, false, null]}");
+    JSON11_TEST_ASSERT(obj.dump() == "{\"k1\": \"v1\", \"k2\": 42, \"k3\": [\"a\", 123.123, true, false, null]}");
 
     JSON11_TEST_ASSERT(Json("a").number_value() == 0);
     JSON11_TEST_ASSERT(Json("a").string_value() == "a");
     JSON11_TEST_ASSERT(Json().number_value() == 0);
 
     JSON11_TEST_ASSERT(obj == json);
-    JSON11_TEST_ASSERT(Json(42) == Json(42.0));
-    JSON11_TEST_ASSERT(Json(42) != Json(42.1));
+    JSON11_TEST_ASSERT(Json(42) == Json(json11::decimal(42.0)));
+    JSON11_TEST_ASSERT(Json(42) != Json(json11::decimal(42.1)));
 
     const string unicode_escape_test =
         R"([ "blah\ud83d\udca9blah\ud83dblah\udca9blah\u0000blah\u1234" ])";


### PR DESCRIPTION
this pull request add decimal floating point support.

without decimal support, 0.1 is not 0.1 as it looks. people from non-C world tend to use decimal directly in their json exchange data, if we don't support decimal, then we lose precision.