### PR TITLE
Add library.json for use with PlatformIO

### DIFF
--- a/json11.cpp
+++ b/json11.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstdio>
+#include <cstdint>
 #include <limits>
 
 namespace json11 {

--- a/library.json
+++ b/library.json
@@ -1,0 +1,19 @@
+{
+    "name": "json11",
+    "description": "A tiny JSON library for C++11.",
+    "keywords": "json",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/dropbox/json11"
+    },
+    "version": "1.0.0",
+    "license": "MIT",
+    "build": {
+        "srcFilter": "+<*> -<test.cpp>"
+    },
+    "export": {
+        "exclude": [
+            "test.cpp"
+        ]
+    }
+}


### PR DESCRIPTION
By adding this file, the library can be added to PlatformIO's library
registry. This way, projects built with PlatformIO can depend on json11
and it will be automatically downloaded from GitHub and linked with the
final program.