### PR TITLE
trivial: Fix -Wold-style-cast

### DIFF
--- a/json11.cpp
+++ b/json11.cpp
@@ -441,9 +441,9 @@ struct JsonParser final {
      */
     char get_next_token() {
         consume_garbage();
-        if (failed) return (char)0;
+        if (failed) return static_cast<char>(0);
         if (i == str.size())
-            return fail("unexpected end of input", (char)0);
+            return fail("unexpected end of input", static_cast<char>(0));
 
         return str[i++];
     }


### PR DESCRIPTION
I got a warning when I compiled json11 with a set of strict warnings. This is a very trivial fix.