### PR TITLE
Protect against literal interpretation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ target_compile_options(json11
 # Set warning flags, which may vary per platform
 include(CheckCXXCompilerFlag)
 set(_possible_warnings_flags /W4 /WX -Wextra -Werror)
-foreach(_warning_flag in ${_possible_warnings_flags})
+foreach(_warning_flag ${_possible_warnings_flags})
   CHECK_CXX_COMPILER_FLAG(${_warning_flag} _flag_supported)
   if(${_flag_supported})
     target_compile_options(json11 PRIVATE ${_warning_flag})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ target_compile_options(json11
 include(CheckCXXCompilerFlag)
 set(_possible_warnings_flags /W4 /WX -Wextra -Werror)
 foreach(_warning_flag ${_possible_warnings_flags})
+  unset(_flag_supported)
   CHECK_CXX_COMPILER_FLAG(${_warning_flag} _flag_supported)
   if(${_flag_supported})
     target_compile_options(json11 PRIVATE ${_warning_flag})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ target_compile_options(json11
 include(CheckCXXCompilerFlag)
 set(_possible_warnings_flags /W4 /WX -Wextra -Werror)
 foreach(_warning_flag in ${_possible_warnings_flags})
-  CHECK_CXX_COMPILER_FLAG(_warning_flag _flag_supported)
+  CHECK_CXX_COMPILER_FLAG(${_warning_flag} _flag_supported)
   if(${_flag_supported})
     target_compile_options(json11 PRIVATE ${_warning_flag})
   endif()


### PR DESCRIPTION
On msvc 2017 this seems to have been checking for existence of a flag called `_warning_flag`