### PR TITLE
Fixes to CMake for MSVC build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,26 @@ endif()
 
 add_library(json11 json11.cpp)
 target_include_directories(json11 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_compile_options(json11
-  PRIVATE -fPIC -fno-rtti -fno-exceptions -Wall)
+if (NOT MSVC)
+  target_compile_options(json11
+    PRIVATE -fPIC -fno-rtti -fno-exceptions -Wall)
+endif()
 
 # Set warning flags, which may vary per platform
 include(CheckCXXCompilerFlag)
-set(_possible_warnings_flags /W4 /WX -Wextra -Werror)
+set(_possible_warnings_flags /W4 /WX)
+#
+# Add Wextra & Werror compiler flags only if not building with Microsoft compiler
+#
+# NOTE:
+#   check_cxx_compiler_flag() for these flags evaluates to positive result
+#   but during build, cl.exe fails with following error
+#   cl : Command line error D8021: invalid numeric argument '/Wextra'
+#
+if (NOT MSVC)
+  set(_possible_warnings_flags ${_possible_warnings_flags} -Wextra -Werror)
+endif()
+
 foreach(_warning_flag ${_possible_warnings_flags})
   unset(_flag_supported)
   CHECK_CXX_COMPILER_FLAG(${_warning_flag} _flag_supported)


### PR DESCRIPTION
MSVC build was failing under Visual Studio 2017 with CMake v3.15.5 and v3.16.2 generated project files.

Compiler cl.exe was failing with following error code for all GCC specific compiler flags
```bash
cl : Command line error D8021: invalid numeric argument '/Wextra'
```

CHECK_CXX_COMPILER_FLAG() evaluates with GCC specific compiler flags to positive result.